### PR TITLE
Organize needs with their proposed solutions and precedents in a table

### DIFF
--- a/problem-solution-matrix.md
+++ b/problem-solution-matrix.md
@@ -62,8 +62,17 @@ based on the most current proposal.
 <td><code>x => Function.pipeAsync(x, ...fns)</code></td>
 <td>
 
-- [`composeP` in Ramda](https://ramdajs.com/docs/#composeP)
 - [`pipeP` in Ramda](https://ramdajs.com/docs/#pipeP)
+
+</td>
+</tr>
+
+<tr>
+<td>To define a function in terms of a series of async function calls in right-to-left order</td>
+<td><code>x => Function.pipeAsync(x, ...fns.reverse())</code></td>
+<td>
+
+- [`composeP` in Ramda](https://ramdajs.com/docs/#composeP)
 
 </td>
 </tr>

--- a/problem-solution-matrix.md
+++ b/problem-solution-matrix.md
@@ -69,6 +69,7 @@ based on the most current proposal.
 <td>
 
 - [`pipeP` in Ramda](https://ramdajs.com/docs/#pipeP)
+- [`p-pipe` by sindresorhus](https://www.npmjs.com/package/p-pipe)
 
 </td>
 </tr>

--- a/problem-solution-matrix.md
+++ b/problem-solution-matrix.md
@@ -22,6 +22,12 @@ based on the most current proposal.
 <td>
 
 - [`pipe` in fp-ts](https://gcanti.github.io/fp-ts/modules/function.ts.html#pipe)
+- [`|>` in F#](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/functions/#function-composition-and-pipelining)
+- [`|>` in Elixir](https://hexdocs.pm/elixir/Kernel.html#%7C%3E/2)
+- [`|>` in Elm](https://package.elm-lang.org/packages/elm/core/latest/Basics#(|%3E))
+- [`|>` in Julia](https://docs.julialang.org/en/v1/base/base/#Base.:%7C%3E)
+- [`|>` in LiveScript](https://livescript.net/#piping)
+- [`Data.Function.&` in Haskell](https://hackage.haskell.org/package/base-4.15.0.0/docs/Data-Function.html#v:-38-)
 
 </td>
 </tr>

--- a/problem-solution-matrix.md
+++ b/problem-solution-matrix.md
@@ -14,7 +14,7 @@ be able to talk about them in a clear and organized way.
 <tbody>
 
 <tr>
-<td>To apply a series of unary functions to a value</td>
+<td>To apply a series of unary functions to a value in left-to-right order</td>
 <td><code>Function.pipe(value, ...fns)</code></td>
 <td>
 
@@ -24,14 +24,14 @@ be able to talk about them in a clear and organized way.
 </tr>
 
 <tr>
-<td>To apply a series of unary async functions to a value</td>
+<td>To apply a series of unary async functions to a value in left-to-right order</td>
 <td><code>Function.pipeAsync(value, ...fns)</code></td>
 <td>
 </td>
 </tr>
 
 <tr>
-<td>To define a function in terms of a series of function calls</td>
+<td>To define a function in terms of a series of function calls in left-to-right order</td>
 <td><code>Function.compose(...fns.reverse())</code></td>
 <td>
 
@@ -43,7 +43,7 @@ be able to talk about them in a clear and organized way.
 </tr>
 
 <tr>
-<td>To define a function in terms of a series of function calls in right to left order</td>
+<td>To define a function in terms of a series of function calls in right-to-left order</td>
 <td><code>Function.compose(...fns)</code></td>
 <td>
 
@@ -54,7 +54,7 @@ be able to talk about them in a clear and organized way.
 </tr>
 
 <tr>
-<td>To define a function in terms of a series of async function calls</td>
+<td>To define a function in terms of a series of async function calls in left-to-right order</td>
 <td>-</td>
 <td>
 
@@ -65,7 +65,7 @@ be able to talk about them in a clear and organized way.
 </tr>
 
 <tr>
-<td>To (partially) compose two unary functions</td>
+<td>To (partially) compose two unary functions in left-to-right order</td>
 <td><code>Function.compose.bind(Function, f)(g)(x)</code></td>
 <td>
 

--- a/problem-solution-matrix.md
+++ b/problem-solution-matrix.md
@@ -3,6 +3,9 @@ discussing whether each separate need has to be addressed by this proposal.
 It's purpose is solely to organize these needs with the proposed solutions to
 be able to talk about them in a clear and organized way.
 
+The "Proposed Solution" is meant to be a living column showing the status quo
+based on the most current proposal.
+
 <table>
 <thead>
 <tr>
@@ -55,7 +58,7 @@ be able to talk about them in a clear and organized way.
 
 <tr>
 <td>To define a function in terms of a series of async function calls in left-to-right order</td>
-<td>-</td>
+<td><code>x => Function.pipeAsync(x, ...fns)</code></td>
 <td>
 
 - [`composeP` in Ramda](https://ramdajs.com/docs/#composeP)

--- a/problem-solution-matrix.md
+++ b/problem-solution-matrix.md
@@ -75,6 +75,7 @@ based on the most current proposal.
 - [`compose` in Sanctuary](https://sanctuary.js.org/#compose)
 - [`map` in Sanctuary](https://sanctuary.js.org/#map)
 - [`map` in Ramda](https://ramdajs.com/docs/#map)
+- [`B` from combinatory logic](https://gist.github.com/Avaq/1f0636ec5c8d6aed2e45)
 
 </td>
 </tr>
@@ -88,6 +89,7 @@ based on the most current proposal.
 - [`always` in Ramda](https://ramdajs.com/docs/#always)
 - [`K` in Sanctuary](https://sanctuary.js.org/#K)
 - [`constant-function` in stdlib](https://stdlib.io/docs/api/latest/@stdlib/utils/constant-function)
+- [`K` from combinatory logic](https://gist.github.com/Avaq/1f0636ec5c8d6aed2e45)
 
 </td>
 </tr>
@@ -101,6 +103,7 @@ based on the most current proposal.
 - [`identity` in Ramda](https://ramdajs.com/docs/#identity)
 - [`I` in Sanctuary](https://sanctuary.js.org/#I)
 - [`identity-function` in stdlib](https://stdlib.io/docs/api/latest/@stdlib/utils/identity-function)
+- [`I` from combinatory logic](https://gist.github.com/Avaq/1f0636ec5c8d6aed2e45)
 
 </td>
 </tr>

--- a/problem-solution-matrix.md
+++ b/problem-solution-matrix.md
@@ -41,6 +41,7 @@ based on the most current proposal.
 - [`flow` in Lodash](https://lodash.com/docs/4.17.15#flow)
 - [`pipe` in Ramda](https://ramdajs.com/docs/#pipe)
 - [`flow` in fp-ts](https://gcanti.github.io/fp-ts/modules/function.ts.html#flow)
+- [`pipe(fns)` in Sanctuary](https://sanctuary.js.org/#pipe)
 
 </td>
 </tr>

--- a/problem-solution-matrix.md
+++ b/problem-solution-matrix.md
@@ -33,7 +33,6 @@
 - [`flow` in Lodash](https://lodash.com/docs/4.17.15#flow)
 - [`pipe` in Ramda](https://ramdajs.com/docs/#pipe)
 - [`flow` in fp-ts](https://gcanti.github.io/fp-ts/modules/function.ts.html#flow)
-
 - [`compose(...fns.reverse())` in Ramda](https://ramdajs.com/docs/#compose)
 
 </td>

--- a/problem-solution-matrix.md
+++ b/problem-solution-matrix.md
@@ -30,8 +30,11 @@
 <td><code>Function.compose(...fns.reverse())</code></td>
 <td>
 
-- [`compose` in Ramda](https://ramdajs.com/docs/#compose)
+- [`flow` in Lodash](https://lodash.com/docs/4.17.15#flow)
 - [`pipe` in Ramda](https://ramdajs.com/docs/#pipe)
+- [`flow` in fp-ts](https://gcanti.github.io/fp-ts/modules/function.ts.html#flow)
+
+- [`compose(...fns.reverse())` in Ramda](https://ramdajs.com/docs/#compose)
 
 </td>
 </tr>

--- a/problem-solution-matrix.md
+++ b/problem-solution-matrix.md
@@ -85,7 +85,7 @@ based on the most current proposal.
 </tr>
 
 <tr>
-<td>To (partially) compose two unary functions in left-to-right order</td>
+<td>To (partially) compose two unary functions in right-to-left order</td>
 <td><code>Function.compose.bind(Function, f)(g)(x)</code></td>
 <td>
 

--- a/problem-solution-matrix.md
+++ b/problem-solution-matrix.md
@@ -128,5 +128,18 @@ based on the most current proposal.
 </td>
 </tr>
 
+<tr>
+<td>A way to run side effects inside a functional pipeline</td>
+<td><code>x => { sideEffect(x); return x; }</code></td>
+<td>
+
+- [`tap` in Ramda](https://ramdajs.com/docs/#tap)
+- [`tap` in lodash](https://lodash.com/docs/4.17.15#tap)
+- [`inspect` in Rust](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.inspect)
+- [`Debug.Trace` on Hackage](https://hackage.haskell.org/package/base-4.15.0.0/docs/Debug-Trace.html)
+
+</td>
+</tr>
+
 </tbody>
 </table>

--- a/problem-solution-matrix.md
+++ b/problem-solution-matrix.md
@@ -1,0 +1,89 @@
+<table>
+<thead>
+<tr>
+<th>Problem Description</th>
+<th>Proposed Solution</th>
+<th>Precedents</th>
+</tr>
+</thead>
+<tbody>
+
+<tr>
+<td>To apply a series of unary functions to a value</td>
+<td><code>Function.pipe(value, ...fns)</code></td>
+<td>
+
+- [`pipe` in fp-ts](https://gcanti.github.io/fp-ts/modules/function.ts.html#pipe)
+
+</td>
+</tr>
+
+<tr>
+<td>To apply a series of unary async functions to a value</td>
+<td><code>Function.pipeAsync(value, ...fns)</code></td>
+<td>
+</td>
+</tr>
+
+<tr>
+<td>To define a function in terms of a series of function calls</td>
+<td><code>Function.compose(...fns.reverse())</code></td>
+<td>
+
+- [`compose` in Ramda](https://ramdajs.com/docs/#compose)
+- [`pipe` in Ramda](https://ramdajs.com/docs/#pipe)
+
+</td>
+</tr>
+
+<tr>
+<td>To define a function in terms of a series of async function calls</td>
+<td>-</td>
+<td>
+
+- [`composeP` in Ramda](https://ramdajs.com/docs/#composeP)
+- [`pipeP` in Ramda](https://ramdajs.com/docs/#pipeP)
+
+</td>
+</tr>
+
+<tr>
+<td>To (partially) compose two unary functions</td>
+<td><code>Function.compose.bind(Function, f)(g)(x)</code></td>
+<td>
+
+- [`compose` in Sanctuary](https://sanctuary.js.org/#compose)
+- [`map` in Sanctuary](https://sanctuary.js.org/#map)
+- [`map` in Ramda](https://ramdajs.com/docs/#map)
+
+</td>
+</tr>
+
+<tr>
+<td>To create a function that always returns the same value</td>
+<td><code>Function.constant(value)</code></td>
+<td>
+
+- [`constant` in lodash](https://lodash.com/docs/4.17.15#constant)
+- [`always` in Ramda](https://ramdajs.com/docs/#always)
+- [`K` in Sanctuary](https://sanctuary.js.org/#K)
+- [`constant-function` in stdlib](https://stdlib.io/docs/api/latest/@stdlib/utils/constant-function)
+
+</td>
+</tr>
+
+<tr>
+<td>A function that returns its input unchanged to be used as an argument to HOFs</td>
+<td><code>Function.identity</code></td>
+<td>
+
+- [`identity` in lodash](https://lodash.com/docs/4.17.15#identity)
+- [`identity` in Ramda](https://ramdajs.com/docs/#identity)
+- [`I` in Sanctuary](https://sanctuary.js.org/#I)
+- [`identity-function` in stdlib](https://stdlib.io/docs/api/latest/@stdlib/utils/identity-function)
+
+</td>
+</tr>
+
+</tbody>
+</table>

--- a/problem-solution-matrix.md
+++ b/problem-solution-matrix.md
@@ -93,6 +93,7 @@ based on the most current proposal.
 - [`map` in Sanctuary](https://sanctuary.js.org/#map)
 - [`map` in Ramda](https://ramdajs.com/docs/#map)
 - [`B` from combinatory logic](https://gist.github.com/Avaq/1f0636ec5c8d6aed2e45)
+- [`.` in Haskell](https://hackage.haskell.org/package/base-4.15.0.0/docs/Prelude.html#v:.)
 
 </td>
 </tr>
@@ -107,6 +108,7 @@ based on the most current proposal.
 - [`K` in Sanctuary](https://sanctuary.js.org/#K)
 - [`constant-function` in stdlib](https://stdlib.io/docs/api/latest/@stdlib/utils/constant-function)
 - [`K` from combinatory logic](https://gist.github.com/Avaq/1f0636ec5c8d6aed2e45)
+- [`const` in Haskell](https://hackage.haskell.org/package/base-4.15.0.0/docs/Prelude.html#v:const)
 
 </td>
 </tr>
@@ -121,6 +123,7 @@ based on the most current proposal.
 - [`I` in Sanctuary](https://sanctuary.js.org/#I)
 - [`identity-function` in stdlib](https://stdlib.io/docs/api/latest/@stdlib/utils/identity-function)
 - [`I` from combinatory logic](https://gist.github.com/Avaq/1f0636ec5c8d6aed2e45)
+- [`id` in Haskell](https://hackage.haskell.org/package/base-4.15.0.0/docs/Prelude.html#v:id)
 
 </td>
 </tr>

--- a/problem-solution-matrix.md
+++ b/problem-solution-matrix.md
@@ -33,7 +33,17 @@
 - [`flow` in Lodash](https://lodash.com/docs/4.17.15#flow)
 - [`pipe` in Ramda](https://ramdajs.com/docs/#pipe)
 - [`flow` in fp-ts](https://gcanti.github.io/fp-ts/modules/function.ts.html#flow)
-- [`compose(...fns.reverse())` in Ramda](https://ramdajs.com/docs/#compose)
+
+</td>
+</tr>
+
+<tr>
+<td>To define a function in terms of a series of function calls in right to left order</td>
+<td><code>Function.compose(...fns)</code></td>
+<td>
+
+- [`compose` in Ramda](https://ramdajs.com/docs/#compose)
+- [`flowRight` in Lodash](https://lodash.com/docs/4.17.15#flowRight)
 
 </td>
 </tr>

--- a/problem-solution-matrix.md
+++ b/problem-solution-matrix.md
@@ -1,7 +1,12 @@
+The table below talks about "developer needs" without having validated them or
+discussing whether each separate need has to be addressed by this proposal.
+It's purpose is solely to organize these needs with the proposed solutions to
+be able to talk about them in a clear and organized way.
+
 <table>
 <thead>
 <tr>
-<th>Problem Description</th>
+<th>Developer Need</th>
 <th>Proposed Solution</th>
 <th>Precedents</th>
 </tr>


### PR DESCRIPTION
# :information_source: [Moved to the Wiki](https://github.com/js-choi/proposal-function-helpers/wiki/FP-Use-Cases)

The information in this pull request has been [moved to a Wiki page](https://github.com/js-choi/proposal-function-helpers/wiki/FP-Use-Cases).

----

I worked on a table to address #2, to somewhat address #3, to illustrate why I opened #5, and to show where this proposal leaves "holes" if the problem space would be viewed as a matrix. I decided to add it via a pull request (without intent for it being merged) so that it would be easier to organize feedback and collaborate to flesh it out.

See [the rendered document](https://github.com/Avaq/proposal-function-helpers/blob/avaq/problem-solution-matrix/problem-solution-matrix.md) here.